### PR TITLE
Add CI workflow for caching SIF and python check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Restore SIF from cache
+        id: cache-sif
+        uses: actions/cache@v3
+        with:
+          path: |
+            sifs/.cache
+            sifs/ompc-base_latest.sif
+          key: ${{ runner.os }}-sif-${{ hashFiles('sifs/get_image.sh') }}
+
+      - name: Download SIF image
+        if: steps.cache-sif.outputs.cache-hit != 'true'
+        run: |
+          cd sifs
+          bash get_image.sh
+
+      - name: Validate Python scripts
+        run: |
+          python -m py_compile $(git ls-files '*.py')


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to fetch and cache the apptainer SIF
- ensure python scripts have correct syntax

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f4b3bd7e08330b93c5eed18d78c3c